### PR TITLE
Fix manual capture issues.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-#"fatal" | "error" | "warn" | "info" | "debug" | "trace"
-APP_DEBUG=info
-SECRET_KEY=aaaaaaaa

--- a/src/modules/webhooks/stripe-webhook.ts
+++ b/src/modules/webhooks/stripe-webhook.ts
@@ -433,15 +433,12 @@ function stripePaymentIntentEventToPartialTransactionEventReportMutationVariable
   switch (stripeEvent.type) {
     // handling these is required
     case "payment_intent.succeeded": {
+      if (manualCapture) break;
       const amount = getSaleorAmountFromStripeAmount({
         amount: manualCapture ? paymentIntent.amount_capturable : paymentIntent.amount_received,
         currency: paymentIntent.currency,
       });
-      const type =
-        // manualCapture
-        //   ? TransactionEventTypeEnum.AuthorizationSuccess
-        //   :
-        TransactionEventTypeEnum.ChargeSuccess;
+      const type = TransactionEventTypeEnum.ChargeSuccess;
 
       return { amount, type, externalUrl, pspReference, message };
     }

--- a/src/modules/webhooks/stripe-webhook.ts
+++ b/src/modules/webhooks/stripe-webhook.ts
@@ -437,9 +437,11 @@ function stripePaymentIntentEventToPartialTransactionEventReportMutationVariable
         amount: manualCapture ? paymentIntent.amount_capturable : paymentIntent.amount_received,
         currency: paymentIntent.currency,
       });
-      const type = manualCapture
-        ? TransactionEventTypeEnum.AuthorizationSuccess
-        : TransactionEventTypeEnum.ChargeSuccess;
+      const type =
+        // manualCapture
+        //   ? TransactionEventTypeEnum.AuthorizationSuccess
+        //   :
+        TransactionEventTypeEnum.ChargeSuccess;
 
       return { amount, type, externalUrl, pspReference, message };
     }

--- a/src/modules/webhooks/stripe-webhook.ts
+++ b/src/modules/webhooks/stripe-webhook.ts
@@ -437,7 +437,9 @@ function stripePaymentIntentEventToPartialTransactionEventReportMutationVariable
         amount: manualCapture ? paymentIntent.amount_capturable : paymentIntent.amount_received,
         currency: paymentIntent.currency,
       });
-      const type = TransactionEventTypeEnum.ChargeSuccess;
+      const type = manualCapture
+        ? TransactionEventTypeEnum.AuthorizationSuccess
+        : TransactionEventTypeEnum.ChargeSuccess;
 
       return { amount, type, externalUrl, pspReference, message };
     }
@@ -501,10 +503,9 @@ function stripePaymentIntentEventToPartialTransactionEventReportMutationVariable
         amount: paymentIntent.amount,
         currency: paymentIntent.currency,
       });
-      const type =
-        paymentIntent.status == "requires_capture"
-          ? TransactionEventTypeEnum.AuthorizationSuccess
-          : TransactionEventTypeEnum.AuthorizationAdjustment;
+      const type = manualCapture
+        ? TransactionEventTypeEnum.AuthorizationSuccess
+        : TransactionEventTypeEnum.AuthorizationAdjustment;
       return { amount, type, externalUrl, pspReference, message };
     }
 

--- a/src/modules/webhooks/stripe-webhook.ts
+++ b/src/modules/webhooks/stripe-webhook.ts
@@ -503,7 +503,10 @@ function stripePaymentIntentEventToPartialTransactionEventReportMutationVariable
         amount: paymentIntent.amount,
         currency: paymentIntent.currency,
       });
-      const type = TransactionEventTypeEnum.AuthorizationAdjustment;
+      const type =
+        paymentIntent.status == "requires_capture"
+          ? TransactionEventTypeEnum.AuthorizationSuccess
+          : TransactionEventTypeEnum.AuthorizationAdjustment;
       return { amount, type, externalUrl, pspReference, message };
     }
 

--- a/src/modules/webhooks/stripe-webhook.ts
+++ b/src/modules/webhooks/stripe-webhook.ts
@@ -437,9 +437,7 @@ function stripePaymentIntentEventToPartialTransactionEventReportMutationVariable
         amount: manualCapture ? paymentIntent.amount_capturable : paymentIntent.amount_received,
         currency: paymentIntent.currency,
       });
-      const type = manualCapture
-        ? TransactionEventTypeEnum.AuthorizationSuccess
-        : TransactionEventTypeEnum.ChargeSuccess;
+      const type = TransactionEventTypeEnum.ChargeSuccess;
 
       return { amount, type, externalUrl, pspReference, message };
     }

--- a/src/modules/webhooks/transaction-charge-requested.ts
+++ b/src/modules/webhooks/transaction-charge-requested.ts
@@ -67,6 +67,7 @@ export const TransactionChargeRequestedWebhookHandler = async (
       pspReference,
       amount,
       externalUrl,
+      availableActions: ["REFUND"],
     };
     return transactionChargeRequestedResponse;
   } else {

--- a/src/modules/webhooks/transaction-charge-requested.ts
+++ b/src/modules/webhooks/transaction-charge-requested.ts
@@ -67,6 +67,7 @@ export const TransactionChargeRequestedWebhookHandler = async (
       pspReference,
       amount,
       externalUrl,
+      //@ts-expect-error: just for testing
       availableActions: ["REFUND"],
     };
     return transactionChargeRequestedResponse;

--- a/src/modules/webhooks/transaction-charge-requested.ts
+++ b/src/modules/webhooks/transaction-charge-requested.ts
@@ -67,7 +67,7 @@ export const TransactionChargeRequestedWebhookHandler = async (
       pspReference,
       amount,
       externalUrl,
-      actions: ["REFUND"],
+      actions: result === "CHARGE_SUCCESS" ? ["REFUND"] : ["CANCEL", "CHARGE"],
     };
     return transactionChargeRequestedResponse;
   } else {

--- a/src/modules/webhooks/transaction-charge-requested.ts
+++ b/src/modules/webhooks/transaction-charge-requested.ts
@@ -67,8 +67,7 @@ export const TransactionChargeRequestedWebhookHandler = async (
       pspReference,
       amount,
       externalUrl,
-      //@ts-expect-error: just for testing
-      actions: result === "CHARGE_SUCCESS" ? ["REFUND"] : ["CANCEL", "CHARGE"],
+      actions: ["REFUND"],
     };
     return transactionChargeRequestedResponse;
   } else {

--- a/src/modules/webhooks/transaction-charge-requested.ts
+++ b/src/modules/webhooks/transaction-charge-requested.ts
@@ -68,7 +68,7 @@ export const TransactionChargeRequestedWebhookHandler = async (
       amount,
       externalUrl,
       //@ts-expect-error: just for testing
-      availableActions: ["REFUND"],
+      actions: result === "CHARGE_SUCCESS" ? ["REFUND"] : ["CANCEL", "CHARGE"],
     };
     return transactionChargeRequestedResponse;
   } else {

--- a/src/schemas/TransactionChargeRequested/TransactionChargeRequestedResponse.schema.json
+++ b/src/schemas/TransactionChargeRequested/TransactionChargeRequestedResponse.schema.json
@@ -7,7 +7,10 @@
     "amount": { "$ref": "definitions.json#/definitions/PositiveDecimal" },
     "time": { "$ref": "definitions.json#/definitions/DateTime" },
     "externalUrl": { "type": "string" },
-    "message": { "type": "string" }
+    "message": { "type": "string" },
+    "actions": {
+      "$ref": "definitions.json#/definitions/TransactionActions"
+    }
   },
   "additionalProperties": false,
   "required": ["pspReference"]


### PR DESCRIPTION
This pull request fixes issues with manual capture:

- On TransactionChargeRequested event, actions should be returned based on response, to ensure actions on the transaction is correctly updated..
- payment_intent.succeeded shouldn't be used in a manual capture setup.
- amount_capturable_updated event should be used to set TransactionEventTypeEnum.AuthorizationSuccess instead of TransactionEventTypeEnum.AuthorizationAdjustment as per stripe documentation https://docs.stripe.com/payments/payment-intents/verifying-status.

