### PR TITLE
deploy saleor-app-payment-stripe to fly.io with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# syntax = docker/dockerfile:1
+ARG NODE_VERSION=22.9.0
+FROM node:${NODE_VERSION}-slim AS base
+ENV NODE_VERSION="$NODE_VERSION"
+
+
+LABEL fly_launch_runtime="Next.js"
+
+# Next.js app lives here
+WORKDIR /app
+
+# Install pnpm
+ARG PNPM_VERSION=8.12.0
+RUN npm install -g pnpm@$PNPM_VERSION
+
+
+FROM base AS build
+
+# Set these via `docker run -e APP_DEBUG=debug ...`
+# OR set them in your deployed containers environment secrets
+# these are needed for pnpm install schema:generate
+ENV APL='file'
+ENV APP_DEBUG='debug'
+# do not replace these here, set these in the deployed environment, or docker run -e ...
+# ENV TEST_SALEOR_API_URL=''
+# ENV UPSTASH_TOKEN=''
+# ENV UPSTASH_URL=''
+# ENV SECRET_KEY='test-see-comment-above'
+
+
+ENV NODE_ENV="production"
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prod=false
+
+COPY . .
+RUN SECRET_KEY='test-see-comment-above' pnpm run build
+# Remove development dependencies
+RUN pnpm prune --prod
+# Final stage for app image
+FROM base
+
+# Copy built application
+COPY --from=build /app /app
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD [ "pnpm", "run", "start" ]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ci": "CI=true vitest --coverage --reporter=json --reporter=default && tsx fix-coverage-report.cjs",
     "migrate": "pnpm tsx ./src/run-migrations.ts",
     "ts-node-esm": "node --loader ts-node/esm --experimental-specifier-resolution=node",
-    "prepare": "husky install",
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "github:release": "pnpm changeset tag && git push --follow-tags"
   },
   "saleor": {


### PR DESCRIPTION
I was facing some deployment issues with what was in the `canary` autogenerated fly.io Dockerfile

1) Related to: https://github.com/pnpm/pnpm/issues/4770#issuecomment-1285854089
2) When deploying, to fly.io, it didn't appear the ENVs were being set, probably a security issue since env vars are being set?
3) i had to do some weirdness with the `--legacy-peers-dep` to get the graphql codegen to run
4) the installation of json schema compiler as well


Wondering if maybe I was just doing it wrong, but maybe someone else will find this useful:


```
git clone git@github.com:saleor/saleor-app-payment-stripe.git
fly login
fly launch
fly set secrets APP_DEBUG=debug SECRET_KEY=$SECRET_KEY APL=file
fly deploy
```

Or:

```
docker build -t stripe-app  . 
# and then
docker run -e 'SECRET_KEY=okay-test-okay' -it stripe-app
```